### PR TITLE
Patch for send keys

### DIFF
--- a/build/lib/commands/gestures.js
+++ b/build/lib/commands/gestures.js
@@ -94,7 +94,11 @@ commands.setValue = commands.replaceValue = commands.setValueImmediate = async f
 
   await (0, _utils.wait4sec)(0.5);
 
-  _privateapis.default.keyboard_typeStringCopyPaste(_v);
+  for (let i in values) {
+    await (0, _utils.wait4sec)(0.1);
+    
+    _privateapis.default.keyboard_typeStringCopyPaste(values[i]);
+  }
 
   return null;
 };

--- a/lib/commands/gestures.js
+++ b/lib/commands/gestures.js
@@ -50,7 +50,10 @@ commands.setValue = commands.replaceValue = commands.setValueImmediate = async f
   await wait4sec(0.1);
   apis.keyboard_tapKeyCode(65535, 0); // delete
   await wait4sec(0.5);
-  apis.keyboard_typeStringCopyPaste(_v);
+  for (let i in values) {
+    await wait4sec(0.1);
+    apis.keyboard_typeStringCopyPaste(values[i]);
+  }
   return null;
 };
 


### PR DESCRIPTION
Fix for the problem when "sendKeys" command writes only the first character of the string